### PR TITLE
Add pass that performs a dereferencing NULL check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# Build directory
+build/
+
+# Hidden cache directory used by clangd
+.cache/
+
+# Debug symbols
+*.dSYM/
+
 # Prerequisites
 *.d
 
@@ -30,3 +39,7 @@
 *.exe
 *.out
 *.app
+
+# LLVM IR and bitcode
+*.ll
+*.bc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,9 @@ if (${SUPPORTS_FVISIBILITY_INLINES_HIDDEN_FLAG} EQUAL "1")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility-inlines-hidden")
 endif()
 
+# Export compile commands for editors
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 # Set the build directories
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")

--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ level of complexity.
 |[**RIV**](#riv) | finds reachable integer values for each basic block | Analysis |
 |[**DuplicateBB**](#duplicatebb) | duplicates basic blocks, requires **RIV** analysis results | CFG |
 |[**MergeBB**](#mergebb) | merges duplicated basic blocks | CFG |
+|[**LoadChecker**](#loadchecker) | checks for dereferenced nullptrs | Transformation |
 
 Once you've [built](#building--testing) this project, you can experiment with
 every pass separately. All passes, except for
@@ -948,6 +949,19 @@ The values are subtracted from each other and the absolute value of their
 difference is calculated. If this absolute difference is less than the value of
 the machine epsilon, the original two floating-point values are considered to
 be equal.
+
+## LoadChecker
+The **LoadChecker** pass is a transformation pass that checks if load
+instructions are trying to dereference a NULL pointer.
+
+### Run the pass
+We will use [input_for_load.c](inputs/input_for_load.c) to test **LoadChecker**.
+
+```bash
+export LLVM_DIR=<installation/dir/of/llvm/18>
+$LLVM_DIR/bin/clang -emit-llvm -S <source_dir>/inputs/input_for_load.c -o input_for_load.ll
+$LLVM_DIR/bin/opt -load-pass-plugin=<build_dir>/lib/libLoadChecker.so -passes="load-checker" -S input_for_load.ll -o loadchecked.ll
+```
 
 Debugging
 ==========

--- a/include/LoadChecker.h
+++ b/include/LoadChecker.h
@@ -1,0 +1,25 @@
+//=============================================================================
+// FILE:
+//   LoadChecker.h
+// 
+// DESCRIPTION:
+//   Declares a LoadChecker pass for the new pass manager.
+//
+// LICENSE: MIT
+//=============================================================================
+
+#ifndef LLVM_TUTOR_LOAD_CHECKER_H
+#define LLVM_TUTOR_LOAD_CHECKER_H
+
+#include "llvm/IR/PassManager.h"
+#include "llvm/Pass.h"
+
+struct LoadChecker : public llvm::PassInfoMixin<LoadChecker> {
+  llvm::PreservedAnalyses run(llvm::Module& M,
+                              llvm::ModuleAnalysisManager&);
+  bool runOnModule(llvm::Module& M);
+
+  static bool isRequired() { return true; }
+};
+
+#endif // LLVM_TUTOR_LOAD_CHECKER_H

--- a/inputs/input_for_load.c
+++ b/inputs/input_for_load.c
@@ -1,0 +1,62 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+
+int* globalPtr = NULL;
+int** globalPtrPtr = &globalPtr;
+
+int getMax(int* array, unsigned n) {
+  int max = 0;
+  for(unsigned i = 0; i < n; i++) {
+    if(array[i] > max) {
+      max = array[i];
+    }
+  }
+  return max;
+}
+
+int getMin(int* array, unsigned n) {
+  int min = 1000;
+  for(unsigned i = 0; i < n; i++) {
+    if(array[i] < min) {
+      min = array[i];
+    }
+  }
+  return min;
+}
+
+int main(int argc, char* argv[]) {
+  unsigned n;
+
+  printf("Please enter an array size: ");
+  scanf("%u", &n);
+
+  int* array = (int*)malloc(n * sizeof(int));
+
+  srand(time(NULL));
+  for(unsigned i = 0; i < n; i++) {
+    array[i] = rand() % 1000;
+  }
+
+  int firstEl = *array;
+  int lastEl = *(array + n - 1);
+
+  printf("First: %d, last: %d, min: %d, max: %d\n", firstEl, lastEl, getMin(array, n), getMax(array, n));
+
+  free(array);
+  array = NULL;
+
+  int* heapInt = (int*)malloc(sizeof(int));
+  array += (int64_t)heapInt / sizeof(int);
+  array = heapInt;
+  *array = 1;
+
+  free(array);
+  array = *globalPtrPtr;
+
+  int badFirstEl = 0;
+  badFirstEl = *array;
+  int ret = badFirstEl & 0;
+
+  return ret;
+}

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,6 +12,7 @@ set(LLVM_TUTOR_PLUGINS
     DuplicateBB
     OpcodeCounter
     MergeBB
+    LoadChecker
     )
 
 set(StaticCallCounter_SOURCES
@@ -36,6 +37,8 @@ set(OpcodeCounter_SOURCES
   OpcodeCounter.cpp)
 set(MergeBB_SOURCES
   MergeBB.cpp)
+set(LoadChecker_SOURCES
+  LoadChecker.cpp)
 
 # CONFIGURE THE PLUGIN LIBRARIES
 # ==============================

--- a/lib/LoadChecker.cpp
+++ b/lib/LoadChecker.cpp
@@ -1,0 +1,143 @@
+//=============================================================================
+// FILE:
+//   LoadChecker.cpp
+//
+// DESCRIPTION:
+//   Checks if load instructions dereference a nullptr. If they do, this 
+//   plugin prints an error message (using debug info if available) and exits 
+//   the process early.
+//
+// USAGE:
+//   $ opt -load-pass-plugin <BUILD_DIR>/lib/libLoadChecker.so \
+//     -passes="load-checker" <bitcode-file> -o instrumented.bin
+//   $ lli instrumented.bin
+//
+// LICENSE: MIT
+//=============================================================================
+#include "LoadChecker.h"
+
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/Passes/PassBuilder.h"
+#include "llvm/Passes/PassPlugin.h"
+
+#define DEBUG_TYPE "load-checker"
+
+bool LoadChecker::runOnModule(llvm::Module& M) {
+  bool instrumented = false;
+
+  auto& CTX = M.getContext();
+
+  for(auto& F : M) {
+    for(auto& BB : F) {
+      for(auto& I : BB) {
+        if(auto* loadInst = llvm::dyn_cast<llvm::LoadInst>(&I); loadInst) {
+          llvm::Value* addr = loadInst->getOperand(0);
+          const auto& debugLoc = loadInst->getDebugLoc();
+          // IRBuilder will insert before the loadInst
+          llvm::IRBuilder<> builder(loadInst);
+          // Compare the adress to the to NULL
+          auto* cmp = builder.CreateICmpEQ(addr, llvm::ConstantPointerNull::get(llvm::dyn_cast<llvm::PointerType>(addr->getType())));
+          // Create a function to check if the addr is NULL and exit early
+          std::string funcName = "nullChecker";
+          // Debug info will only be available if the `-g` option was passed to clang
+          if(debugLoc) {
+            funcName += "_";
+            funcName += std::to_string(debugLoc.getLine());
+            funcName += "_";
+            funcName += std::to_string(debugLoc.getCol());
+          }
+          const bool funcExists = M.getFunction(funcName) != nullptr;
+          llvm::FunctionType* nullCheckerTy = llvm::FunctionType::get(llvm::Type::getVoidTy(CTX),
+                                                                      {cmp->getType()},
+                                                                      /*IsVarArgs=*/false);
+          llvm::FunctionCallee nullCheckerC = M.getOrInsertFunction(funcName, nullCheckerTy);
+          if(!funcExists) {
+            llvm::Function* nullCheckerF = llvm::dyn_cast<llvm::Function>(nullCheckerC.getCallee());
+            // Create a basic blocks for nullCheckerF
+            llvm::BasicBlock* entryBlock = llvm::BasicBlock::Create(CTX, "enter", nullCheckerF);
+            llvm::BasicBlock* isNullBlock = llvm::BasicBlock::Create(CTX, "is_null", nullCheckerF);
+            llvm::BasicBlock* retBlock = llvm::BasicBlock::Create(CTX, "ret", nullCheckerF);
+            llvm::IRBuilder<> funcBuilder(entryBlock);
+            funcBuilder.CreateCondBr(nullCheckerF->getArg(0), isNullBlock, retBlock);
+            // Inject a declaration of 'printf'
+            llvm::FunctionType *printfTy = llvm::FunctionType::get(llvm::Type::getInt32Ty(CTX),
+                                                                   llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(CTX)),
+                                                                   /*IsVarArgs=*/true);
+            llvm::FunctionCallee printfC = M.getOrInsertFunction("printf", printfTy);
+            llvm::Function* printfF = llvm::dyn_cast<llvm::Function>(printfC.getCallee());
+            printfF->setDoesNotThrow();
+            printfF->addParamAttr(0, llvm::Attribute::NoCapture);
+            printfF->addParamAttr(0, llvm::Attribute::ReadOnly);
+            // Inject a global variable to hold the printf format string
+            std::string errorMsg = "Trying to load a NULL pointer";
+            if(debugLoc) {
+              errorMsg += " at line ";
+              errorMsg += std::to_string(debugLoc.getLine());
+              errorMsg += ", col ";
+              errorMsg += std::to_string(debugLoc.getCol());
+            }
+            errorMsg += ". Exiting early.\n";
+            llvm::Constant* errorMsgStr = llvm::ConstantDataArray::getString(CTX, errorMsg);
+            std::string gblVarName = "ErrorMsg";
+            if(debugLoc) {
+              gblVarName += "_";
+              gblVarName += std::to_string(debugLoc.getLine());
+              gblVarName += "_";
+              gblVarName += std::to_string(debugLoc.getCol());
+            }
+            llvm::Constant* errorMsgGbl = M.getOrInsertGlobal(gblVarName, errorMsgStr->getType());
+            llvm::dyn_cast<llvm::GlobalVariable>(errorMsgGbl)->setInitializer(errorMsgStr);
+            // Inject a declaration of 'exit'
+            llvm::FunctionType* exitTy = llvm::FunctionType::get(llvm::Type::getVoidTy(CTX),
+                                                                 {llvm::Type::getInt32Ty(CTX)},
+                                                                 /*IsVarArgs=*/false);
+            llvm::FunctionCallee exitC = M.getOrInsertFunction("exit", exitTy);
+            // Create contents for isNullBlock and retBlock
+            funcBuilder.SetInsertPoint(isNullBlock);
+            llvm::Value* errorMsgGblPtr =
+              funcBuilder.CreatePointerCast(errorMsgGbl,
+                                            llvm::PointerType::getUnqual(llvm::Type::getInt8Ty(CTX)));
+            funcBuilder.CreateCall(printfC, {errorMsgGblPtr});
+            funcBuilder.CreateCall(exitC, {llvm::ConstantInt::get(llvm::Type::getInt32Ty(CTX), llvm::APInt(32, 1))});
+            funcBuilder.CreateBr(retBlock);
+            funcBuilder.SetInsertPoint(retBlock);
+            funcBuilder.CreateRetVoid();
+          }
+          // Add function that checks for null
+          builder.CreateCall(nullCheckerC, {cmp});
+        }
+      }
+    }
+  }
+
+  return instrumented;
+}
+
+llvm::PreservedAnalyses LoadChecker::run(llvm::Module& M,
+                                         llvm::ModuleAnalysisManager&) {
+  bool instrumented = runOnModule(M);
+
+  return instrumented ? llvm::PreservedAnalyses::none()
+                      : llvm::PreservedAnalyses::all();
+}
+
+llvm::PassPluginLibraryInfo getLoadCheckerPluginInfo() {
+  return {LLVM_PLUGIN_API_VERSION, "load-checker", LLVM_VERSION_STRING,
+          [](llvm::PassBuilder& PB) {
+            PB.registerPipelineParsingCallback(
+              [](llvm::StringRef name, llvm::ModulePassManager& MPM,
+                 llvm::ArrayRef<llvm::PassBuilder::PipelineElement>) {
+                if(name == "load-checker") {
+                  MPM.addPass(LoadChecker());
+                  return true;
+                }
+                return false;
+              });
+          }};
+}
+
+extern "C" LLVM_ATTRIBUTE_WEAK llvm::PassPluginLibraryInfo
+llvmGetPassPluginInfo() {
+  return getLoadCheckerPluginInfo();
+}


### PR DESCRIPTION
The pass is called LoadChecker because it checks if LLVM IR load instructions try to dereference a NULL pointer.